### PR TITLE
Change to update the git repo for keystone

### DIFF
--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -26,6 +26,6 @@
   scm: git
   version: master
 - name: os_keystone
-  src: https://github.com/os-cloud/openstack-ansible-os_keystone
+  src: https://github.com/openstack/openstack-ansible-os_keystone
   scm: git
   version: master

--- a/ansible-role-requirements.yml
+++ b/ansible-role-requirements.yml
@@ -26,6 +26,6 @@
   scm: git
   version: master
 - name: os_keystone
-  src: https://github.com/openstack/openstack-ansible-os_keystone
+  src: https://git.openstack.org/openstack/openstack-ansible-os_keystone
   scm: git
   version: master


### PR DESCRIPTION
This change updates the git repo for the os_keystone role to use 
the official openstack role as maintained by the OpenStack-Ansible
community.